### PR TITLE
fix: handle bad input without crashing

### DIFF
--- a/altcodes4linux.py
+++ b/altcodes4linux.py
@@ -72,9 +72,19 @@ def main(args):
 
             # convert alt code to equivalent Unicode code point
             codepage = 'cp1252' if currentAltCode[0]=='0' else 'cp850'
-            altCodeDec = int(currentAltCode)
-            altCodeChar = ord(altCodeDec.to_bytes(1, 'big').decode(codepage))
-            altCodeHex = ('%0.2X' % altCodeChar).upper()
+            try:
+                altCodeDec = int(currentAltCode)
+                altCodeChar = ord(altCodeDec.to_bytes(1, 'big').decode(codepage))
+                altCodeHex = ('%0.2X' % altCodeChar).upper()
+            except Exception as e:
+                print('ALTCODE: ', currentAltCode, ' not recognized --> ignored (',e,')')
+                currentAltCode = None
+                # ALT key is still pressed - press again to avoid opening menus
+                vinput.write(evdev.ecodes.EV_KEY, keyEvent.scancode, 1)
+                vinput.syn()
+                vinput.write(evdev.ecodes.EV_KEY, keyEvent.scancode, 0)
+                vinput.syn()
+                continue
             print('ALTCODE: ', currentAltCode, '('+str(altCodeDec)+')', ' --> ', '0x'+altCodeHex, ' [ '+chr(altCodeChar)+' ]')
             currentAltCode = None
 


### PR DESCRIPTION
wrap decoding process into try-except to avoid crashing the program when the user enters invalid codes.